### PR TITLE
[REF] Cleanest implementation of API.

### DIFF
--- a/cfdilib/cfdilib.py
+++ b/cfdilib/cfdilib.py
@@ -20,14 +20,53 @@ class Struct(object):
 
 
 class BaseDocument:
-    """Meta model for an xml document from a dictionary and an xsd file, this is
-    the one that will be used To simplify the conversion and prepare the document for a signature.
+    """An XML document following any format given an XSD file.
+    Due to avoid duplication of work we will delegate the error management
+    Of attributes to the xsd, then the `validate` method will make the job of
+    return the correct error, due to the standard managend on the invoice.
+
+    The template itself must comply with an specific xsd, this is needed to
+    simply pass a dictionary of terms used in the template convert them to
+    attributes of this Document object using whatever attributes comes from that xsd
+
+    Then due to the template itself has all the structure of attributes
+    necessaries to comply with the xsd, theoretically the xsd should return the
+    logical error which we are not complying on such template, see cfdv32.xml template to see
+    how you should assembly a new version of this template, then set it to the
+    template_fname attribute and guala your dict will be magically validated
+    and converted to an XML file.
+
+    Why not assembly with simple lxml?
+    ----------------------------------
+
+    Because it is more readable and configurable, it is always more simple
+    inherit a class and set an attribute than overwrite hundreds of methods
+    when it is a big xml.
     """
+
+    @abstractmethod
+    def __init__(self, dict_document, debug_mode=False):
+        """Convert a dictionary invoice to a Class
+
+        @param :dict_invoice Dictionary with all entries you will need in your
+        template.
+        """
+        self.debug_mode = debug_mode
+        self.set_schema_fname()
+        self.set_schema(self.schema_fname)
+        self.__dict__.update(dict_document)
+        for k, v in dict_document.items():
+            if isinstance(v, dict):
+                self.__dict__[k] = Struct(v)
 
     __metaclass__ = ABCMeta
     output_file = NamedTemporaryFile(delete=False)
     input_file = NamedTemporaryFile(delete=False)
     ups = False
+
+    def set_schema_fname(self):
+        """The same than template but with .xsd on templates folder."""
+        self.schema_fname = self.template_fname.replace('.xml', '.xsd')
 
     def guess_autoescape(self, template_name):
         '''Given a template Name I will gues using its extension if we should autoscape or not.
@@ -53,7 +92,7 @@ class BaseDocument:
                           autoescape=self.guess_autoescape)
         return env.get_template(template_fname)
 
-    def validate(self, schema_str, xml_valid):
+    def validate(self, schema_str, xml_valid):  # TODO: be able to get doc for error given an xsd.
         """Compare the valid information on an xml from  given schema.
 
         :param str schema_str: content string from schema file.
@@ -72,6 +111,21 @@ class BaseDocument:
             result = False
         finally:
             return result
+
+    def set_xml(self):
+        """document xml just rendered already validated against xsd to be signed.
+
+        :params boolean debug_mode: Either if you want the rendered template to be saved either it
+        is valid or not with the given schema.
+
+        :returns boolean: Either was valid or not the generated document.
+        """
+        document = self.template.render(inv=self)
+        self.document = False
+        if self.debug_mode:
+            self.document = document
+        if self.validate(self.schema, document):
+            self.document = document
 
     def get_element_from_clark(self, element):
         '''**Helper method:** Given a Clark's Notation `{url:schema}Element` element, return the
@@ -104,80 +158,3 @@ class BaseDocument:
         document = schema_root.xpath(self.get_element_from_clark(element),
                                      namespaces=namespace)
         return document and document[0].text or ''
-
-
-class Invoice32(BaseDocument):
-    """An invoice object following 3.2 CFDI legal format.
-    Due to avoid duplication of work we will delegate the error management
-    Of attributes to the xsd, then the `validate` method will make the job of
-    return the correct error, due to the standard managend on the invoice.
-
-    The template itself must comply with an specific xsd, this is needed to
-    simply pass a dictionary of terms used in the template convert them to
-    attributes of this Invoice32 object using whatever attributes comes there
-
-    Then due to the template itself has all the structure of attributes
-    necessaries to comply with the xsd, theretically the xsd should return the
-    logical error which we are not complying, see cfdv32.xml template to see
-    how you should assembly a new version of this template, then set it to the
-    template_fname attribute and guala your dict will be magically validated
-    and converted to an XML file.
-
-    Why not assembly with simple lxml?
-    ----------------------------------
-
-    Because it is more readable and configurable, it is always more simple
-    inherit a class and set an attribute than overwrite hundreds of methods
-    when it is a big xml.
-    """
-
-    def __init__(self, dict_invoice, debug_mode=False):
-        """Convert a dictionary invoice to a Class
-
-        @param :dict_invoice Dictionary with all entries you will need in your
-        template.
-        """
-        self.debug_mode = debug_mode
-        self.set_template_fname()
-        self.set_schema_fname()
-        self.set_template(self.template_fname)
-        self.set_schema(self.schema_fname)
-        self.__dict__.update(dict_invoice)
-        for k, v in dict_invoice.items():
-            if isinstance(v, dict):
-                self.__dict__[k] = Struct(v)
-        self.set_cfd()
-
-    def set_template_fname(self):
-        """Wired to a known file which is a jinja2 valid template
-        it works as an API."""
-        self.template_fname = 'cfdv32.xml'
-
-    def set_schema_fname(self):
-        """The same than template but with .xsd on templates folder."""
-        self.schema_fname = self.template_fname.replace('.xml', '.xsd')
-
-    def set_template(self, template_fname):
-        self.template = super(Invoice32, self).set_template(template_fname)
-
-    def set_schema(self, schema_fname):
-        self.schema = super(Invoice32, self).set_schema(schema_fname)
-
-    def set_cfd(self):
-        """cfd: xml just rendered already validated against xsd to be signed.
-
-        :params boolean debug_mode: Either if you want the rendered template to be saved either it
-        is valid or not with the given schema.
-
-        :returns boolean: Either was valid or not the generated document.
-        """
-        cfd = self.template.render(inv=self)
-        self.cfd = False
-        if self.debug_mode:
-            self.cfd = cfd
-        if self.validate(self.schema, cfd):
-            self.cfd = cfd
-
-
-def get_invoice(dict_invoice, debug_mode=False):
-    return Invoice32(dict_invoice, debug_mode=debug_mode)

--- a/cfdilib/cfdv32.py
+++ b/cfdilib/cfdv32.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from cfdilib import BaseDocument
+
+class CFDv32(BaseDocument):
+    """Invoice document to comply with cfdi: v3.2 for Invoice Mexico Standards."""
+
+    def __init__(self, dict_invoice, debug_mode=False):
+        self.set_template_fname()
+        self.set_template(self.template_fname)
+        super(CFDv32, self).__init__(dict_invoice, debug_mode=False)
+        # This method must be called from the inherited __init__ always AFTER the super.
+        self.set_xml()
+
+    def set_template_fname(self):
+        """Wired to a known file which is a jinja2 valid template
+        it works as an API then the file must be in template folder on library dict
+        """
+        # TODO: Idea: may be it can be configurable in order to take the template from other
+        # folder or even from the StringIO Itself.
+        self.template_fname = 'cfdv32.xml'
+
+    def set_template(self, template_fname):
+        self.template = super(CFDv32, self).set_template(template_fname)
+
+    def set_schema(self, schema_fname):
+        self.schema = super(CFDv32, self).set_schema(schema_fname)
+
+def get_invoice(dict_invoice, debug_mode=False):
+    return CFDv32(dict_invoice, debug_mode=debug_mode)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,7 +111,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'default'  # TODO: pick and hack odoo's theme
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the

--- a/invoice32.py
+++ b/invoice32.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+from cfdilib import BaseDocument
+
+class Invoice32(BaseDocument):
+    """An invoice object following 3.2 CFDI legal format.
+    Due to avoid duplication of work we will delegate the error management
+    Of attributes to the xsd, then the `validate` method will make the job of
+    return the correct error, due to the standard managend on the invoice.
+
+    The template itself must comply with an specific xsd, this is needed to
+    simply pass a dictionary of terms used in the template convert them to
+    attributes of this Invoice32 object using whatever attributes comes there
+
+    Then due to the template itself has all the structure of attributes
+    necessaries to comply with the xsd, theretically the xsd should return the
+    logical error which we are not complying, see cfdv32.xml template to see
+    how you should assembly a new version of this template, then set it to the
+    template_fname attribute and guala your dict will be magically validated
+    and converted to an XML file.
+
+    Why not assembly with simple lxml?
+    ----------------------------------
+
+    Because it is more readable and configurable, it is always more simple
+    inherit a class and set an attribute than overwrite hundreds of methods
+    when it is a big xml.
+    """
+
+    def __init__(self, dict_invoice, debug_mode=False):
+        """Convert a dictionary invoice to a Class
+
+        @param :dict_invoice Dictionary with all entries you will need in your
+        template.
+        """
+        self.debug_mode = debug_mode
+        self.set_template_fname()
+        self.set_schema_fname()
+        self.set_template(self.template_fname)
+        self.set_schema(self.schema_fname)
+        self.__dict__.update(dict_invoice)
+        for k, v in dict_invoice.items():
+            if isinstance(v, dict):
+                self.__dict__[k] = Struct(v)
+        self.set_cfd()
+
+    def set_template_fname(self):
+        """Wired to a known file which is a jinja2 valid template
+        it works as an API."""
+        self.template_fname = 'cfdv32.xml'
+
+    def set_schema_fname(self):
+        """The same than template but with .xsd on templates folder."""
+        self.schema_fname = self.template_fname.replace('.xml', '.xsd')
+
+    def set_template(self, template_fname):
+        self.template = super(Invoice32, self).set_template(template_fname)
+
+    def set_schema(self, schema_fname):
+        self.schema = super(Invoice32, self).set_schema(schema_fname)
+
+    def set_cfd(self):
+        """cfd: xml just rendered already validated against xsd to be signed.
+
+        :params boolean debug_mode: Either if you want the rendered template to be saved either it
+        is valid or not with the given schema.
+
+        :returns boolean: Either was valid or not the generated document.
+        """
+        cfd = self.template.render(inv=self)
+        self.cfd = False
+        if self.debug_mode:
+            self.cfd = cfd
+        if self.validate(self.schema, cfd):
+            self.cfd = cfd
+
+
+def get_invoice(dict_invoice, debug_mode=False):
+    return Invoice32(dict_invoice, debug_mode=debug_mode)

--- a/tests/test_cfdilib.py
+++ b/tests/test_cfdilib.py
@@ -11,7 +11,7 @@ Tests for `cfdilib` module.
 from os.path import join, dirname
 import unittest
 
-from cfdilib import cfdilib
+from cfdilib import cfdilib, cfdv32
 
 
 class TestCfdilib(unittest.TestCase):
@@ -31,26 +31,26 @@ class TestCfdilib(unittest.TestCase):
 
     def test_001_get_xsd_documentation(self):
         '''Getting a documentation from a given Clark's Notated xsd element'''
-        invoice = cfdilib.get_invoice(self.dict_invoice_basic_32)
+        invoice = cfdv32.get_invoice(self.dict_invoice_basic_32)
         self.assertTrue(invoice.get_documentation('{http://www.sat.gob.mx/cfd/3}Impuestos')
                         .find('impuestos aplicables') > 0,
                         'Documentation did not returns the expected element')
 
     def test_002_get_cfd_debugged(self):
         '''validate that with a given valid dict an invoice object is created in debug_mode'''
-        invoice = cfdilib.get_invoice(self.dict_invoice_basic_32, debug_mode=True)
-        self.assertTrue(invoice.cfd,
+        invoice = cfdv32.get_invoice(self.dict_invoice_basic_32, debug_mode=True)
+        self.assertTrue(invoice.document,
                         'A valid dictionary gave error debugged_mode enabled gave an error.')
 
     def test_003_get_cfd(self):
         '''validate that with a given valid dict an invoice object is created in debug_mode'''
-        invoice = cfdilib.get_invoice(self.dict_invoice_basic_32, debug_mode=False)
-        self.assertTrue(invoice.cfd,
+        invoice = cfdv32.get_invoice(self.dict_invoice_basic_32, debug_mode=False)
+        self.assertTrue(invoice.document,
                         'A valid dictionary gave error an error')
 
     def test_004_get_errored(self):
         '''validate that with a given invalid dict raise properly errors on ups object'''
-        invoice = cfdilib.get_invoice(self.dict_invoice_basic_32_errored)
+        invoice = cfdv32.get_invoice(self.dict_invoice_basic_32_errored)
 
         self.assertTrue(invoice.ups,
                       'An invalid dictionary gave a valid output, that is wrong.')


### PR DESCRIPTION
To show a cleanest implementation I moved all generic methods to the correct metaclass and renamed all wired names related to mx stndards to the correct places. Generalizd the documentation.
