### PR TITLE
[IMP] cfdilib: Added validations that elements exist in dict.

### DIFF
--- a/cfdilib/templates/cfdv32.xml
+++ b/cfdilib/templates/cfdv32.xml
@@ -46,18 +46,19 @@
             Regimen="{{ inv.emitter_fiscal_position or '' }}"/>
     </cfdi:Emisor>
     <cfdi:Receptor
-        nombre="{{ inv.receiver_name }}"
+        {% if inv.receiver_name %} nombre="{{ inv.receiver_name }}" {% endif %}
         rfc="{{ inv.receiver_rfc }}">
         <cfdi:Domicilio
-            calle="{{ inv.receiver_street }}"
-            codigoPostal="{{ inv.receiver_zip }}"
-            colonia="{{ inv.receiver_colony }}"
-            estado="{{ inv.receiver_state}}"
-            localidad="{{ inv.receiver_locality }}"
-            municipio="{{ inv.receiver_municipality }}"
-            noExterior="{{ inv.receiver_exterior_no }}"
-            noInterior="{{ inv.receiver_interior_no }}"
-            pais="{{ inv.receiver_country }}"/>
+            {% if inv.receiver_street %} calle="{{ inv.receiver_street }}" {% endif %}
+            {% if inv.receiver_zip %} codigoPostal="{{ inv.receiver_zip }}" {% endif %}
+            {% if inv.receiver_colony %} colonia="{{ inv.receiver_colony }}" {% endif %}
+            {% if inv.receiver_state %} estado="{{ inv.receiver_state}}" {% endif %}
+            {% if inv.receiver_locality %} localidad="{{ inv.receiver_locality }}" {% endif %}
+            {% if inv.receiver_municipality %} municipio="{{ inv.receiver_municipality }}" {% endif %}
+            {% if inv.receiver_exterior_no %} noExterior="{{ inv.receiver_exterior_no }}" {% endif %}
+            {% if inv.receiver_interior_no %} noInterior="{{ inv.receiver_interior_no }}" {% endif %}
+            {% if inv.receiver_country %} pais="{{ inv.receiver_country }}" {% endif %}
+            />
     </cfdi:Receptor>
     {% if inv.invoice_lines %}
     <cfdi:Conceptos>


### PR DESCRIPTION
Added validation that element exist in the Receiver section to avoid set
NA when the dict values are empty.

This node have many elements that are not required, and in cases when is
generated the XML without receiver data, the report that is generated
have many NA.

Temporal solution