### PR TITLE
[FIX] cfdilib: Order attribute name with label

### DIFF
--- a/cfdilib/templates/cfdi11balance.xml
+++ b/cfdilib/templates/cfdi11balance.xml
@@ -13,7 +13,7 @@
         Debe="{{ acc.debit }}"
         Haber="{{ acc.credit }}"
         NumCta="{{ acc.number }}"
-        SaldoFin="{{ acc.initial }}"
-        SaldoIni="{{ acc.end }}"/>
+        SaldoFin="{{ acc.end }}"
+        SaldoIni="{{ acc.initial }}"/>
 {% endfor %}
 </BCE:Balanza>


### PR DESCRIPTION
Fix that assign the
SaldoFin like acc.initial
SaldoIni like acc.end