### PR TITLE
[IMP] cfdilib: Added validation to only add CondicionesDePago when is

### DIFF
--- a/cfdilib/templates/cfdv33.xml
+++ b/cfdilib/templates/cfdv33.xml
@@ -3,11 +3,11 @@
     xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     Version="3.3"
-    Serie="{{ inv.serie }}"
-    Folio="{{ inv.number }}"
+    {% if inv.serie %} Serie="{{ inv.serie }}" {% endif %}
+    {% if inv.number %} Folio="{{ inv.number }}" {% endif %}
     Fecha="{{ inv.date_invoice_tz }}"
     Sello=""
-    FormaPago="{{ inv.payment_policy }}"
+    {% if inv.payment_policy %}FormaPago="{{ inv.payment_policy }}" {% endif %}
     NoCertificado="{{ inv.certificate_number }}"
     Certificado="{{ inv.certificate }}"
     {% if inv.conditions %} CondicionesDePago="{{ inv.conditions }}" {% endif %}
@@ -17,7 +17,7 @@
     TipoCambio="{{ inv.rate }}"
     Total="{{ inv.amount_total or 0.0}}"
     TipoDeComprobante="{{ inv.document_type }}"
-    MetodoPago="{{ inv.pay_method }}"
+    {% if inv.pay_method %} MetodoPago="{{ inv.pay_method }}" {% endif %}
     LugarExpedicion="{{ inv.emitter_zip }}"
     {% if inv.confirmation %} Confirmacion="{{ inv.confirmation }}" {% endif %}>
     {% if inv.cfdi_related_type %}

--- a/cfdilib/templates/cfdv33.xml
+++ b/cfdilib/templates/cfdv33.xml
@@ -10,7 +10,7 @@
     FormaPago="{{ inv.payment_policy }}"
     NoCertificado="{{ inv.certificate_number }}"
     Certificado="{{ inv.certificate }}"
-    CondicionesDePago="{{ inv.conditions }}"
+    {% if inv.conditions %} CondicionesDePago="{{ inv.conditions }}" {% endif %}
     SubTotal="{{ inv.subtotal or 0.0 }}"
     {% if inv.discount_amount %} Descuento="{{ inv.discount_amount }}" {% endif %}
     Moneda="{{ inv.currency }}"


### PR DESCRIPTION
present.

This attribute is optional, and if is added with '' show the next error:
attribute 'CondicionesDePago': [facet 'minLength'] The value '' has a
length of '0'