### PR TITLE
[IMP] cfdilib: Unidad attribute optional in lines

### DIFF
--- a/cfdilib/templates/cfdv33.xml
+++ b/cfdilib/templates/cfdv33.xml
@@ -45,7 +45,7 @@
             {% if line.code %} NoIdentificacion="{{ line.code }}" {% endif %}
             Cantidad="{{ line.quantity }}"
             ClaveUnidad="{{ line.code_unit }}"
-            Unidad="{{ line.unit }}"
+            {% if line.unit %} Unidad="{{ line.unit }}" {% endif %}
             Descripcion="{{ line.name }}"
             ValorUnitario="{{ line.price_unit or 0.0 }}"
             Importe="{{ line.subtotal_wo_discount or 0.0 }}"


### PR DESCRIPTION
The attribute Unidad is optional in concepts to CFDI version 3.3

![captura de pantalla 2017-07-04 a la s 16 50 12](https://user-images.githubusercontent.com/7606656/27843418-e4e90122-60d8-11e7-8463-2e0bd9f8c56c.png)
