### PR TITLE
[FIX] l10n_mx_base: Attribute NumRegIdTrib validate the structure.

### DIFF
--- a/cfdilib/templates/cfdv33.xml
+++ b/cfdilib/templates/cfdv33.xml
@@ -36,7 +36,7 @@
         Rfc="{{ inv.receiver_rfc }}"
         {% if inv.receiver_name %} Nombre="{{ inv.receiver_name }}" {% endif %}
         {% if inv.receiver_country %} ResidenciaFiscal="{{ inv.receiver_country }}" {% endif %}
-        {% if inv.receiver_reg_trib %} NumRegIdTrib="{{ inv.receiver_reg_trib }}" {% endif %}
+        {% if inv.receiver_reg_trib != 'NA' %} NumRegIdTrib="{{ inv.receiver_reg_trib }}" {% endif %}
         UsoCFDI="{{ inv.receiver_use_cfdi }}"/>
     <cfdi:Conceptos>
         {% for line in inv.invoice_lines %}

--- a/cfdilib/templates/cfdv33.xml
+++ b/cfdilib/templates/cfdv33.xml
@@ -36,7 +36,7 @@
         Rfc="{{ inv.receiver_rfc }}"
         {% if inv.receiver_name %} Nombre="{{ inv.receiver_name }}" {% endif %}
         {% if inv.receiver_country %} ResidenciaFiscal="{{ inv.receiver_country }}" {% endif %}
-        {% if inv.receiver_reg_trib != 'NA' %} NumRegIdTrib="{{ inv.receiver_reg_trib }}" {% endif %}
+        {% if inv.receiver_reg_trib and inv.receiver_reg_trib != 'NA' %} NumRegIdTrib="{{ inv.receiver_reg_trib }}" {% endif %}
         UsoCFDI="{{ inv.receiver_use_cfdi }}"/>
     <cfdi:Conceptos>
         {% for line in inv.invoice_lines %}


### PR DESCRIPTION
This attribute have the next definition:
  Atributo condicional para expresar el número de registro
  de identidad fiscal del receptor cuando sea residente en
  el extranjero. Es requerido cuando se incluya el
  complemento de comercio exterior.

And this validation:
  Si el valor del atributo es un RFC inscrito no cancelado en el SAT o
  un RFC genérico
  nacional, no se debe registrar este atributo. Si no existe el atributo
  ResidenciaFiscal, este
  atributo puede omitirse.
  Si el RFC del receptor es un RFC genérico extranjero y el comprobante
  incluye el
  complemento de comercio exterior, el atributo debe existir.
  Si el atributo ResidenciaFiscal corresponde a una clave de país
  incluida en el catálogo
  c_Pais publicado en la pagina del SAT, se deben verificar las columnas
  correspondientes
  a dicha clave:
   Si tiene mecanismo de verificación en línea incluido en la columna
  “Validación del
  Registro de Identidad Tributaria” del mismo catálogo de c_Pais, debe
  existir en el
  registro del país.
   Si no tiene mecanismo de verificación en línea, debe cumplir con el
  patrón
  correspondiente incluido en la columna “Formato de Registro de
  Identidad
  Tributaria” que se publique en el mismo catálogo c_Pais.
  En otro caso no se aplica esta validación.

Without this change, if the customer is not mexican, set the value NA,
but some countries as USA have a regex to this value, and if the
attribute is empty We get this error:

  El campo NumRegIdTrib no cumple con el patrón correspondiente.

Now, if this value is NA, is not set in he template.