### PR TITLE
[IMP] cfdilib: Removed automatic `NA` assignation to empty values

### DIFF
--- a/cfdilib/cfdilib.py
+++ b/cfdilib/cfdilib.py
@@ -31,11 +31,6 @@ class Struct(object):
         """
         self.__dict__.update(adict)
         for k, v in adict.items():
-            if self.__dict__[k] is False or self.__dict__[k] is None:  # pragma: no cover  # noqa
-                # I did not find a use case hereto test it but it is necessary
-                # to left there when other recursive structure comes in
-                # that's why the no cover, remove this comment if you find one.
-                self.__dict__[k] = u'NA'
             if isinstance(v, dict):
                 self.__dict__[k] = Struct(v)
             if isinstance(v, list):
@@ -95,8 +90,6 @@ class BaseDocument:
         self.set_schema(self.schema_fname)
         self.__dict__.update(dict_document)
         for k, v in dict_document.items():
-            if self.__dict__[k] is False or self.__dict__[k] is None:
-                self.__dict__[k] = u'NA'
             if isinstance(v, dict):
                 self.__dict__[k] = Struct(v)
             if isinstance(v, list):

--- a/cfdilib/templates/cfdv33.xml
+++ b/cfdilib/templates/cfdv33.xml
@@ -33,7 +33,7 @@
         Nombre="{{ inv.emitter_name }}"
         RegimenFiscal="{{ inv.emitter_fiscal_position or ''  }}"/>
     <cfdi:Receptor
-        Rfc="{{ inv.receiver_rfc }}"
+        {% if inv.receiver_rfc %} Rfc="{{ inv.receiver_rfc }}" {% endif %}
         {% if inv.receiver_name %} Nombre="{{ inv.receiver_name }}" {% endif %}
         {% if inv.receiver_country %} ResidenciaFiscal="{{ inv.receiver_country }}" {% endif %}
         {% if inv.receiver_reg_trib and inv.receiver_reg_trib != 'NA' %} NumRegIdTrib="{{ inv.receiver_reg_trib }}" {% endif %}
@@ -41,10 +41,10 @@
     <cfdi:Conceptos>
         {% for line in inv.invoice_lines %}
         <cfdi:Concepto
-            ClaveProdServ="{{ line.code_sat }}"
+            {% if line.code_sat %} ClaveProdServ="{{ line.code_sat }}" {% endif %}
             {% if line.code %} NoIdentificacion="{{ line.code }}" {% endif %}
             Cantidad="{{ line.quantity }}"
-            ClaveUnidad="{{ line.code_unit }}"
+            {% if line.code_unit %} ClaveUnidad="{{ line.code_unit }}" {% endif %}
             {% if line.unit %} Unidad="{{ line.unit }}" {% endif %}
             Descripcion="{{ line.name }}"
             ValorUnitario="{{ line.price_unit or 0.0 }}"


### PR DESCRIPTION
CFDI 3.3 have a extensive catalog, then when is validated the xsd all
the attributes are validated that the value assigned is found in the
catalogs.

Before of this change, if the attribute in the dict values was
empty, this was updated to set NA, but in CFDI 3.3, is validated that
the value exist in the catalog, and take many time in compare the value.

Example in the attribute 'ClaveProdServ' that have 52828 records.

Now, if the value is empty only not add the attribute and do not take
many time because only validate that the attribute is not found.

Why not only add a validation like `if attribute '!=' 'NA'`, because the
catalog to Unit Codes have the record `NA - Miligramo por kilogramo` and
We could ignore that value.
  
Here a time:
<img width="835" alt="captura de pantalla 2018-01-08 a la s 11 10 37" src="https://user-images.githubusercontent.com/7606656/34682485-a2404342-f464-11e7-8336-ae8cc1aa5fff.png">
