### PR TITLE
[FIX] l10n_mx_reports: fix error in general ledger report

### DIFF
--- a/cfdilib/templates/cfdi13moves.xml
+++ b/cfdilib/templates/cfdi13moves.xml
@@ -17,7 +17,7 @@
     <PLZ:Poliza Concepto="{{ move.name }}" Fecha="{{ move.date }}" NumUnIdenPol="{{ move.id }}">
     {% for line in move.line_ids %}
         <PLZ:Transaccion Concepto="{{ line.name }}" DesCta="{{ line.account_id.name }}"
-                         NumCta="{{ line.account_id.code }}" Debe="{{ line.debit }}" Haber="{{ line.credit }}">
+                         NumCta="{{ line.account_id.code }}" Debe="{{ '%.2f' % line.debit|float }}" Haber="{{ '%.2f' % line.credit|float }}">
         </PLZ:Transaccion>
     {% endfor %}
     </PLZ:Poliza>


### PR DESCRIPTION
- Fix error in general ledger report when accounting has more than 2 fractional digits ('%.2f' % line.debit).
- Use **|float** to avoid *TypeError: a float is required* 