### PR TITLE
[IMP] Specific click version

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,6 +8,7 @@ Sphinx==1.3.1
 cryptography==1.0.1
 PyYAML==3.11
 click==6.6
+Markdown==2.0.1
 suds
 jinja2
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ coverage==4.0
 Sphinx==1.3.1
 cryptography==1.0.1
 PyYAML==3.11
-click
+click==6.6
 suds
 jinja2
 


### PR DESCRIPTION
Avoid:

```
cheetah 2.4.4 requires Markdown>=2.0.1, which is not installed.
Installing collected packages: click, backports.functools-lru-cache, cfdilib
```