### PR TITLE
[REF]cfdilib: Avoid set 'Lugar Expedicion' when empty task#25298

### DIFF
--- a/cfdilib/templates/cfdv33.xml
+++ b/cfdilib/templates/cfdv33.xml
@@ -18,7 +18,7 @@
     Total="{{ inv.amount_total or 0.0}}"
     TipoDeComprobante="{{ inv.document_type }}"
     {% if inv.pay_method %} MetodoPago="{{ inv.pay_method }}" {% endif %}
-    LugarExpedicion="{{ inv.emitter_zip }}"
+    {% if inv.emitter_zip %} LugarExpedicion="{{ inv.emitter_zip  }}" {% endif %}
     {% if inv.confirmation %} Confirmacion="{{ inv.confirmation }}" {% endif %}>
     {% if inv.cfdi_related_type %}
         <cfdi:CfdiRelacionados

--- a/cfdilib/templates/cfdv33.xml
+++ b/cfdilib/templates/cfdv33.xml
@@ -18,7 +18,7 @@
     Total="{{ inv.amount_total or 0.0}}"
     TipoDeComprobante="{{ inv.document_type }}"
     {% if inv.pay_method %} MetodoPago="{{ inv.pay_method }}" {% endif %}
-    {% if inv.emitter_zip %} LugarExpedicion="{{ inv.emitter_zip  }}" {% endif %}
+    {% if inv.emitter_zip %} LugarExpedicion="{{ inv.emitter_zip }}" {% endif %}
     {% if inv.confirmation %} Confirmacion="{{ inv.confirmation }}" {% endif %}>
     {% if inv.cfdi_related_type %}
         <cfdi:CfdiRelacionados


### PR DESCRIPTION
Fix issue: https://github.com/Vauxoo/cfdilib/issues/90

When the company do not have zip code the CFDI set False, this takes many
time because it searches for the value in all the catalog,
it is faster if only validate that the attribute is required, but was not
found.

DUMMY: https://git.vauxoo.com/vauxoo/mexico/merge_requests/1233