### PR TITLE
[FIX] l10n_mx_edi_customs: 'NumeroPedimento' only when there is not e…

### DIFF
--- a/cfdilib/templates/cfdv33.xml
+++ b/cfdilib/templates/cfdv33.xml
@@ -80,10 +80,12 @@
                     {% endif %}
                 </cfdi:Impuestos>
             {% endif %}
-            {% for value in line.customs_number %}
-                <cfdi:InformacionAduanera
-                    NumeroPedimento="{{ value.number }}"/>
-            {% endfor %}
+            {% if not inv.l10n_mx_edi_external_trade %}
+                {% for value in line.customs_number %}
+                    <cfdi:InformacionAduanera
+                        NumeroPedimento="{{ value.number }}"/>
+                {% endfor %}
+            {% endif %}
         </cfdi:Concepto>
         {% endfor %}
     </cfdi:Conceptos>


### PR DESCRIPTION
…xternal trade (CFDI)

The attribute `NumeroPedimento` in the CFDI not must be added when the
CFDI has the external trade complement, is a validation that was added the
SAT for this cases.

The improve was designed to do not fail when the external trade module is
not found.

closes odoo#3558